### PR TITLE
fix: remove unused Public IPs from deployments

### DIFF
--- a/admin/src/deployment.yaml
+++ b/admin/src/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     app: admin
-  type: LoadBalancer
   ports:
     - name: admin
       port: 3001

--- a/backend/src/deployment.yaml
+++ b/backend/src/deployment.yaml
@@ -55,7 +55,6 @@ metadata:
 spec:
   selector:
     app: backend
-  type: LoadBalancer
   ports:
     - name: backend
       port: 3000

--- a/postgres/src/deployment.yaml
+++ b/postgres/src/deployment.yaml
@@ -72,7 +72,6 @@ metadata:
   labels:
     app: pgadmin
 spec:
-  type: LoadBalancer
   ports:
     - name: pgadmin
       port: 80

--- a/uptime-kuma/src/deployment.yaml
+++ b/uptime-kuma/src/deployment.yaml
@@ -46,7 +46,6 @@ metadata:
   labels:
     app: uptime-kuma
 spec:
-  type: LoadBalancer
   ports:
     - name: uptime-kuma
       port: 3001

--- a/web/src/deployment.yaml
+++ b/web/src/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     app: web
-  type: LoadBalancer
   ports:
     - name: web
       port: 3000


### PR DESCRIPTION
NOTE: leaving them for databases as security backup to reach them if Cloudflare Tunnels don't work for some reason